### PR TITLE
Working TextRank, outputs the correct dictionary format (shown below), to test change approach under the config file

### DIFF
--- a/src/model/content_selector.py
+++ b/src/model/content_selector.py
@@ -156,8 +156,10 @@ class ContentSelector:
 
         for doc in all_documents.keys():
             sentlist = []
+            sentlist_tok = []
             for paragraph in all_documents[doc].keys():
                 for sentence in all_documents[doc][paragraph]:
+                    sentlist_tok.append(sentence)
                     sentence_str = " ".join(sentence)
                     sentlist.append(sentence_str)
 
@@ -173,13 +175,11 @@ class ContentSelector:
             ranked_sentindices = sorted(range(len(sentence_scores)), key=lambda index: sentence_scores[index], reverse=True)
             top_sentindices = ranked_sentindices[:self.num_sentences_per_doc]
 
-            top_sentences = [sentlist[i] for i in top_sentindices]
+            top_sentences = [sentlist_tok[i] for i in top_sentindices]
 
-            top_sent_wordlists = []
-            for sentence in top_sentences:
-                top_sent_wordlists.append(nltk.word_tokenize(sentence))
+
             # stores top sentences as value in dictionary associated with the doc name as its key
-            selected_sentences[doc] = top_sent_wordlists
+            selected_sentences[doc] = top_sentences
 
         # compiled dictionary of the top n sentences for each document
         return selected_sentences


### PR DESCRIPTION
{'AFP_ENG_20070808.0498': [['US', 'toy', 'company', 'Mattel', 'identified', 'a', 'factory', 'in', 'China', 'involved', 'in', 'producing', 'toys', 'which', 'were', 'recalled', 'in', 'the', 'United', 'States', 'over', 'fears', 'they', 'were', 'tainted', 'with', 'poisonous', 'lead', ',', 'a', 'report', 'said', 'Wednesday', '.'], ['The', 'California-based', 'company', 'named', 'Lee', 'Der', 'Industrial', 'Co.', 'in', 'the', 'southeastern', 'province', 'of', 'Guangdong', 'as', 'the', 'factory', 'involved', 'in', 'Mattel', '``', "'s", "''", 'recall', 'of', '1.5', 'million', 'toys', 'last', 'week', ',', 'the', 'Wall', 'Street', 'Journal', 'reported', '.'], ['Mattel', 'said', 'it', 'was', 'still', 'carrying', 'out', 'an', 'investigation', 'about', 'the', 'recalled', 'products', 'but', 'was', 'no', 'longer', 'accepting', 'shipments', 'from', 'the', 'factory', 'in', 'Guangdong', ',', 'the', 'leading', 'business', 'daily', 'reported', '.']], 
'AFP_ENG_20070809.0173': [['Hansheng', 'Woodware', 'Factory', 'and', 'Lee', 'Der', 'Industrial', 'Co', ',', 'both', 'in', 'southern', 'China', ',', 'can', 'not', 'export', 'until', 'they', '``', 'correct', 'the', 'problems', 'and', 'become', 'qualified', ',', '``', "''", "''", 'China', '``', "'s", "''", 'quality', 'administration', 'said', 'in', 'a', 'statement', 'on', 'its', 'website', '.'], ['Two', 'more', 'US', 'recalls', 'of', 'China-made', 'products', 'came', 'to', 'light', 'Thursday', 'as', 'Beijing', 'cracked', 'down', 'on', 'manufacturers', 'held', 'responsible', 'for', 'a', 'massive', 'recall', 'by', 'toy', 'giant', 'Mattel', 'last', 'week', '.'], ['In', 'the', 'latest', 'in', 'a', 'slew', 'of', 'callbacks', 'of', 'faulty', 'and', 'tainted', 'Chinese', 'products', ',', 'US', 'importer', 'Foreign', 'Tire', 'Sales', 'Inc.', '(', 'FTS', ')', 'of', 'Union', ',', 'New', 'Jersey', ',', 'recalled', '255,000', 'defective', 'Chinese-made', 'automobile', 'tires', ',', 'saying', 'they', 'lacked', 'a', 'key', 'safety', 'feature', 'that', 'could', 'be', 'dangerous', '.']], 
'AFP_ENG_20070810.0620': [['Hansheng', 'Woodware', 'Factory', 'and', 'Lee', 'Der', 'Industrial', 'Co', ',', 'both', 'in', 'southern', 'China', ',', 'can', 'not', 'export', 'until', 'they', '``', 'correct', 'the', 'problems', 'and', 'become', 'qualified', ',', '``', "''", "''", 'China', '``', "'s", "''", 'quality', 'administration', 'said', 'in', 'a', 'statement', 'on', 'its', 'website', '.'], ['Separately', ',', 'the', 'Chicago', 'Tribune', 'reported', 'that', 'US', 'toy', 'firm', 'Schylling', 'Associates', 'voluntarily', 'recalled', '24,000', 'Chinese-made', '``', 'Thomas', '&', 'amp', ';', 'Friends', '``', "''", "''", 'spinning', 'tops', 'from', '2001-2002', 'with', 'wooden', 'knobs', 'that', 'were', 'painted', 'with', 'lead-based', 'paint', '.'], ['In', 'the', 'latest', 'in', 'a', 'slew', 'of', 'callbacks', 'of', 'faulty', 'and', 'tainted', 'Chinese', 'products', ',', 'US', 'importer', 'Foreign', 'Tire', 'Sales', 'Inc.', '(', 'FTS', ')', 'of', 'Union', ',', 'New', 'Jersey', ',', 'recalled', '255,000', 'defective', 'Chinese-made', 'automobile', 'tires', ',', 'saying', 'they', 'posed', 'a', 'hazard', '.']], 
'AFP_ENG_20070814.0142': [['Famous', 'for', 'its', 'Barbie', 'girl', 'dolls', ',', 'which', 'have', 'had', 'numerous', 'fashion', 'make-overs', 'through', 'the', 'years', ',', 'Mattel', 'has', 'a', 'broad', 'stable', 'of', 'other', 'products', 'it', 'markets', 'in', 'toy', 'stores', 'around', 'the', 'globe', '.'], ['In', 'recent', 'years', ',', 'Mattel', 'has', 'faced', 'competition', 'from', 'other', 'toy', 'makers', '``', "'", "''", 'dolls', '.'], ['The', 'world', '``', "'s", "''", 'largest', 'toy', 'maker', 'Mattel', ',', 'which', 'announced', 'a', 'mass', 'recall', 'of', 'over', '18', 'million', 'Chinese-made', 'toys', 'worldwide', 'Tuesday', ',', 'has', 'built', 'its', 'decades-long', 'reputation', 'on', 'its', 'well-known', 'Barbie', 'dolls', '.']], 
'APW_ENG_20070806.1228': [['The', 'Consumer', 'Product', 'Safety', 'Commission', 'is', 'looking', 'into', 'whether', 'Fisher-Price', 'let', 'the', 'agency', 'know', 'as', 'quickly', 'as', 'it', 'should', 'have', 'about', 'lead', 'paint', 'found', 'in', '1.5', 'million', 'Chinese-made', 'toys', 'that', 'were', 'recalled', 'worldwide', 'last', 'week', '.'], ['However', ',', 'Brenda', 'Andolina', ',', 'a', 'Fisher-', 'Price', 'spokeswoman', ',', 'said', 'Fisher-Price', 'informed', 'its', 'retailers', 'July', '26', ',', 'one', 'week', 'before', 'the', 'recall', 'was', 'publicly', 'announced', ',', 'so', 'that', 'they', 'could', 'prepare', '.'], ['He', 'declined', 'to', 'provide', 'details', ',', 'including', 'when', 'Fisher-Price', 'notified', 'authorities', 'of', 'the', 'problem', '.']], 
'APW_ENG_20070809.0719': [['The', 'company', 'was', 'aware', 'of', 'problems', 'with', 'lead', 'paint', 'being', 'used', 'on', 'the', 'knobs', ',', 'he', 'said', '.'], ['Jim', 'Leonard', ',', 'Schylling', '``', "'s", "''", 'chief', 'operating', 'officer', ',', 'said', 'he', 'found', 'a', 'June', '2002', 'test', 'report', 'showing', 'that', 'the', 'top', 'contained', 'lead', 'paint', 'on', 'its', 'wooden', 'knob', '.'], ['The', 'toy', 'company', 'that', 'issued', 'a', 'voluntary', 'recall', 'for', 'a', 'Thomas', '&', 'amp', ';', 'Friends', 'spinning', 'top', 'this', 'week', 'had', 'a', '2002', 'test', 'report', 'showing', 'the', 'toy', 'contained', 'lead', 'paint', ',', 'according', 'to', 'a', 'published', 'report', '.']], 
'APW_ENG_20070810.1405': [['resident', ',', 'who', 'did', '``', "n't", "''", 'have', 'any', 'of', 'the', 'tainted', 'toys', ',', 'said', 'the', 'latest', 'recall', 'will', 'make', 'her', 'focus', 'more', 'on', 'eco-friendly', 'toys', '.'], ['http', ':', '//www.toy-tia.org'], ['Toy', 'experts', 'say', 'that', 'European', 'makers', 'adhere', 'to', 'higher', 'safety', 'standards', 'than', 'in', 'the', 'U.S.', 'And', 'even', 'though', 'European', 'toy', 'makers', 'are', 'shifting', 'some', 'of', 'their', 'production', 'to', 'China', ',', 'the', 'products', 'are', 'required', 'to', 'be', 'tested', 'before', 'they', 're-enter', 'the', 'country', 'of', 'origin', '.']], 
'APW_ENG_20070813.0204': [['The', 'newspaper', 'said', 'that', 'a', 'supplier', ',', 'Zhang', '``', "'s", "''", 'best', 'friend', ',', 'sold', 'Lee', 'Der', 'fake', 'paint', 'which', 'was', 'used', 'in', 'the', 'toys', '.'], ['Zhang', 'Shuhong', ',', 'who', 'ran', 'the', 'Lee', 'Der', 'Industrial', 'Co.', 'Ltd.', ',', 'killed', 'himself', 'at', 'a', 'warehouse', 'over', 'the', 'weekend', ',', 'days', 'after', 'China', 'announced', 'it', 'had', 'temporarily', 'banned', 'exports', 'by', 'the', 'company', ',', 'the', 'Southern', 'Metropolis', 'Daily', 'said', '.'], ['A', 'company', 'official', 'who', 'answered', 'the', 'telephone', 'at', 'Lee', 'Der', 'on', 'Monday', 'said', 'he', 'had', 'not', 'heard', 'of', 'the', 'news', '.']], 
'APW_ENG_20070814.0090': [['Until', 'now', ',', 'Fisher-Price', 'and', 'parent', 'company', 'Mattel', 'had', 'never', 'recalled', 'toys', 'because', 'of', 'lead', 'paint', '.'], ['Mattel', 'Inc.', 'is', 'set', 'to', 'announce', 'the', 'recall', 'of', 'a', 'Chinese-made', 'toy', 'as', 'early', 'as', 'Tuesday', 'because', 'it', 'may', 'contain', 'excessive', 'amounts', 'of', 'lead', 'paint', '.'], ['The', 'expected', 'announcement', 'would', 'mark', 'the', 'second', 'recall', 'involving', 'lead', 'paint', 'by', 'the', 'world', '``', "'s", "''", 'largest', 'toy', 'maker', 'within', 'two', 'weeks', '.']], 
'XIN_ENG_20070808.0291': [['China', 'said', 'on', 'Wednesday', 'that', 'the', 'United', 'States', 'importers', 'and', 'brand', 'owners', 'should', 'take', 'responsibility', 'for', 'recalled', 'toys', ',', 'as', 'statistics', 'showed', 'the', 'U.S.', 'product', 'quality', 'watchdog', 'filed', '29', 'recall', 'cases', 'involving', 'toys', 'made', 'in', 'China', 'in', '2006', '.'], ['On', 'Aug.', '2', ',', 'another', 'toy', 'company', ',', 'Fisher-Price', ',', 'also', 'recalled', 'more', 'than', 'one', 'million', 'character', 'toys', 'with', 'unqualified', 'paint', '.'], ['The', 'recall', 'of', 'the', 'magnetic', 'construction', 'toys', 'by', 'the', 'U.S.', 'Consumer', 'Product', 'Safety', 'Commission', '(', 'CPSC', ')', ',', 'for', 'example', ',', 'was', 'caused', 'by', 'the', 'brand', 'owner', '``', "'s", "''", 'design', 'but', 'not', 'the', 'OEM', ',', 'said', 'the', 'spokesman', '.']]}